### PR TITLE
CDKTemplate bugfix

### DIFF
--- a/template.c
+++ b/template.c
@@ -821,10 +821,12 @@ void setCDKTemplateValue (CDKTEMPLATE *cdktemplate, const char *newValue)
    int copychars        = 0;
    int x;
 
+   /* Erase the old value. */
+   cleanCDKTemplate (cdktemplate);
+
    /* Just to be sure, if let's make sure the new value isn't null. */
    if (newValue == 0)
    {
-      cleanCDKTemplate (cdktemplate);
       return;
    }
 
@@ -832,8 +834,7 @@ void setCDKTemplateValue (CDKTEMPLATE *cdktemplate, const char *newValue)
    len = (int)strlen (newValue);
    copychars = MINIMUM (len, cdktemplate->fieldWidth);
 
-   /* OK, erase the old value, and copy in the new value. */
-   cdktemplate->info[0] = '\0';
+   /* OK, copy in the new value. */
    strncpy (cdktemplate->info, newValue, (size_t) copychars);
 
    /* Use the function which handles the input of the characters. */
@@ -881,7 +882,9 @@ boolean getCDKTemplateBox (CDKTEMPLATE *cdktemplate)
 void cleanCDKTemplate (CDKTEMPLATE *cdktemplate)
 {
    /* *INDENT-EQLS* */
-   cdktemplate->info[0]   = '\0';
+   int i;
+   for(i=cdktemplate->fieldWidth ; i>=0 ; i--)
+   	cdktemplate->info[i]   = '\0';
    cdktemplate->screenPos = 0;
    cdktemplate->infoPos   = 0;
    cdktemplate->platePos  = 0;


### PR DESCRIPTION
An issue occuring when `setCDKTemplateValue` and `cleanCDKTemplate`
called, is fixed.

Signed-off-by: Aarian P. Aleahmad <aleahmad@hpds.ir>